### PR TITLE
Bug Fix: Allow For Token ID to be 0

### DIFF
--- a/src/components/common/SelectableNumberField.vue
+++ b/src/components/common/SelectableNumberField.vue
@@ -17,7 +17,7 @@
             this.model_ = oldValue
           }
         } else {
-          if (value.match(/^[1-9][0-9]*$/)) {
+          if (value.match(/^[0-9][0-9]*$/)) {
             this.model_ = value.toString()
           } else {
             this.model_ = oldValue


### PR DESCRIPTION
## This PR

Changes the `.match` call we use within `SelectableNumberField.vue ` to allow for Token IDs of `0` to pass. Previously, the field would simply not let your write `0` and overwrite it to `1` over and over again.

## Details

This change must be made as tokens can have an ID of 0.
Example:
https://etherscan.io/address/0xc51a5c5c91b22c86c3493891883d8402f437e411#readContract

## QA

* [x] Can now check for token ID 0 on the contract mentioned above
 <img width="835" alt="Screen Shot 2021-10-23 at 6 25 05 PM" src="https://user-images.githubusercontent.com/6632701/138573445-ee4c2f00-10c0-4e4e-9339-6b5c2d1b7889.png">

